### PR TITLE
Update index.html

### DIFF
--- a/monitor/templates/index.html
+++ b/monitor/templates/index.html
@@ -8,6 +8,12 @@
 
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+    <style type="text/css">
+        .list-group-item small {
+            width: 100%;
+            word-wrap: break-word;
+        }
+    </style>
 </head>
 <body>
     {% if is_forked %}


### PR DESCRIPTION
Just a minor cosmetic thing. Added some CSS to ensure that the hashes don't spill out of their containers. They'll now wrap gracefully at smaller viewport sizes.

Here's a screenshot of how the hashes currently render without this style:

<img width="100%" alt="screen shot 2017-07-18 at 6 46 09 pm" src="https://user-images.githubusercontent.com/986721/28343085-8875d1a6-6be9-11e7-873f-4b6ac2951daf.png">
